### PR TITLE
Added keywords so that it can be installed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,9 @@
     "test",
     "tests"
   ],
+  "keywords": [
+    "plugin-api-2"
+  ],
   "dependencies": {
     "d3": "^3.5.17"
   }


### PR DESCRIPTION
The plugin-api-2 is now required to allow installation on the 31+ version of cockpit (developer build at this time).
